### PR TITLE
fast-next-js dependency update

### DIFF
--- a/fast_node_js/fast_next_js/package.json
+++ b/fast_node_js/fast_next_js/package.json
@@ -12,7 +12,7 @@
   "author": "hjh",
   "license": "ISC",
   "dependencies": {
-    "next": "^9.5.5",
+    "next": "^11.0.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1"
   }


### PR DESCRIPTION
1. next js version higher than 11.0.0 due to dependency potential security vulnerability